### PR TITLE
async spies please

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,31 @@ describe('your secret training is complete', function (expect) {
     expect(doubleOhSeven).toHaveBeenCalled();
 });
 ```
+Pass a closured reference into async blocks to avoid having your spied functions reset.
+```js
+var obj = {
+    method: function () {
+        console.log('original');
+    }
+};
+
+describe('test some stuff', function () {
+    describe('do something async', function () {
+        spy.on(obj, 'method', function () {
+            console.log('spied');
+        });
+        var spiedFn = obj.method; // save into a new reference that can be closured below
+        setTimeout(function () {
+            // must be used here as `spiedFn` not as `obj.method`
+            spiedFn(1); // output: "spied"
+        }, 10);
+    });
+    describe('do something async', function () {
+        obj.method(); // output: "original"
+    });
+});
+
+```
 
 ---
 

--- a/test/index.js
+++ b/test/index.js
@@ -62,7 +62,7 @@ passing(function () {
                     console.log = CONSOLE.log;
                     console.log();
                     validate.all(CONSOLE.history, [
-'\nAll 33 tests passed!',
+'\nAll 35 tests passed!',
 '\n(1 tests skipped)',
 '\nAll 3 tests passed!',
 '\nFailed tests:',

--- a/test/specs/features/spy.js
+++ b/test/specs/features/spy.js
@@ -64,6 +64,12 @@ describe('spy', function () {
 
     describe('works asyncronously', function () {
 
+        // NOTE: Spies must be reset after each describe block completes!
+        // They cannot wait for done to be called in an async block
+        // because if they did, the fn would still be spied on
+        // during the next sync block. That's not what we want.
+        // So, to use a spied fn in an async block, we must pass a closured reference...
+
         describe('works with setTimeout', function (expect, done) {
             var originalCalled = 0;
             var replacementCalled = 0;
@@ -85,8 +91,9 @@ describe('spy', function () {
 
             describe('inside1', function () {
                 describe('inside2', function () {
+                    var spiedFn = obj.method; // must be passed as a new closured ref
                     setTimeout(function () {
-                        obj.method(1);
+                        spiedFn(1);
                         validate();
                     }, 10);
                 });
@@ -114,14 +121,15 @@ describe('spy', function () {
 
             describe('inside1', function () {
                 describe('inside2', function () {
-                    let p = new Promise((resolve, reject) => {
-                        obj.method(1);
+                    var spiedFn = obj.method; // must be passed as a new closured ref
+                    var p = new Promise((resolve, reject) => {
+                        spiedFn(1);
                         setTimeout(() => {
                             resolve();
                         }, 10);
                     });
                     p.then((success) => {
-                        obj.method(1);
+                        spiedFn(1);
                         validate();
                     });
                 });

--- a/test/specs/features/spy.js
+++ b/test/specs/features/spy.js
@@ -62,4 +62,71 @@ describe('spy', function () {
         expect(replaced).toBe(true);
     });
 
+    describe('works asyncronously', function () {
+
+        describe('works with setTimeout', function (expect, done) {
+            var originalCalled = 0;
+            var replacementCalled = 0;
+            var obj = {
+                method: function (arg) {
+                    originalCalled += arg;
+                }
+            };
+
+            function validate() {
+                expect(originalCalled).toBe(0);
+                expect(replacementCalled).toBe(1);
+                done();
+            }
+
+            spy.on(obj, 'method', function (arg) {
+                replacementCalled += arg;
+            });
+
+            describe('inside1', function () {
+                describe('inside2', function () {
+                    setTimeout(function () {
+                        obj.method(1);
+                        validate();
+                    }, 10);
+                });
+            });
+        });
+
+        describe('works with Promise', function (expect, done) {
+            var originalCalled = 0;
+            var replacementCalled = 0;
+            var obj = {
+                method: function (arg) {
+                    originalCalled += arg;
+                }
+            };
+
+            function validate() {
+                expect(originalCalled).toBe(0);
+                expect(replacementCalled).toBe(2);
+                done();
+            }
+
+            spy.on(obj, 'method', function (arg) {
+                replacementCalled += arg;
+            });
+
+            describe('inside1', function () {
+                describe('inside2', function () {
+                    let p = new Promise((resolve, reject) => {
+                        obj.method(1);
+                        setTimeout(() => {
+                            resolve();
+                        }, 10);
+                    });
+                    p.then((success) => {
+                        obj.method(1);
+                        validate();
+                    });
+                });
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
Spies must always be reset after each describe block finishes its initial invokation. We can't wait for `done()` to be called in an async block to trigger the reset because if we did, the spied method would still be spied on during the next sync block (given that the next sync block usually executes before the first async block is "done"). That's not what we want.

So, to use a spied method in an async block, we must pass a new closured reference that points to the desired function and allow the original method to be reset.
(see the example in the specs)